### PR TITLE
adds support for route names and http methods in the array for routes

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -104,10 +104,11 @@ class Router
         }
 
         if (!empty($options['routes'])) {
-            foreach ($options['routes'] as $path => $routeConfig) {
-                $name = $path;
+            foreach ($options['routes'] as $name => $routeConfig) {
                 if (array_key_exists('path', $routeConfig)) {
                     $path = $routeConfig['path'];
+                } else {
+                    $path = $name;
                 }
                 $this->addRouteFromConfig($path, $routeConfig, $name);
             }

--- a/src/Router.php
+++ b/src/Router.php
@@ -105,22 +105,23 @@ class Router
 
         if (!empty($options['routes'])) {
             foreach ($options['routes'] as $name => $routeConfig) {
-                if (array_key_exists('path', $routeConfig)) {
-                    $path = $routeConfig['path'];
-                } else {
-                    $path = $name;
-                }
-                $this->addRouteFromConfig($path, $routeConfig, $name);
+                $this->addRouteFromConfig($name, $routeConfig);
             }
         }
     }
 
     /**
-     * @param string $path
+     * @param string $name
      * @param array $routeConfig
      */
-    private function addRouteFromConfig($path, array $routeConfig, $name)
+    private function addRouteFromConfig($name, array $routeConfig)
     {
+        if (array_key_exists('path', $routeConfig)) {
+            $path = $routeConfig['path'];
+        } else {
+            $path = $name;
+        }
+
         $defaults = isset($routeConfig['defaults']) ? $routeConfig['defaults'] : [];
         $requirements = isset($routeConfig['requirements']) ? $routeConfig['requirements'] : [];
         $methods = isset($routeConfig['methods']) ? $routeConfig['methods'] : [];
@@ -155,11 +156,11 @@ class Router
      * Add route.
      *
      * @param Route $route
-     * @param string|null $route
+     * @param string|null $name
      */
     public function addRoute(Route $route, $name = null)
     {
-        if (null === $name) {
+        if ($name === null) {
             $name = $route->getPath();
         }
         $this->routes->add($name, $route);

--- a/src/Router.php
+++ b/src/Router.php
@@ -122,7 +122,7 @@ class Router
     {
         $defaults = isset($routeConfig['defaults']) ? $routeConfig['defaults'] : [];
         $requirements = isset($routeConfig['requirements']) ? $routeConfig['requirements'] : [];
-        $methods = isset($routeConfig['methods']) ? $routeConfig['methods'] : [Request::METHOD_GET];
+        $methods = isset($routeConfig['methods']) ? $routeConfig['methods'] : [];
         $this->addRoute(new Route($path, $defaults, $requirements, [], '', [], $methods), $name);
     }
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -104,8 +104,8 @@ class Router
         }
 
         if (!empty($options['routes'])) {
-            foreach ($options['routes'] as $name => $routeConfig) {
-                $this->addRouteFromConfig($name, $routeConfig);
+            foreach ($options['routes'] as $nameOrPath => $routeConfig) {
+                $this->addRouteFromConfig($nameOrPath, $routeConfig);
             }
         }
     }

--- a/src/Router.php
+++ b/src/Router.php
@@ -105,11 +105,25 @@ class Router
 
         if (!empty($options['routes'])) {
             foreach ($options['routes'] as $path => $routeConfig) {
-                $defaults = isset($routeConfig['defaults']) ? $routeConfig['defaults'] : [];
-                $requirements = isset($routeConfig['requirements']) ? $routeConfig['requirements'] : [];
-                $this->addRoute(new Route($path, $defaults, $requirements));
+                $name = $path;
+                if (array_key_exists('path', $routeConfig)) {
+                    $path = $routeConfig['path'];
+                }
+                $this->addRouteFromConfig($path, $routeConfig, $name);
             }
         }
+    }
+
+    /**
+     * @param string $path
+     * @param array $routeConfig
+     */
+    private function addRouteFromConfig($path, array $routeConfig, $name)
+    {
+        $defaults = isset($routeConfig['defaults']) ? $routeConfig['defaults'] : [];
+        $requirements = isset($routeConfig['requirements']) ? $routeConfig['requirements'] : [];
+        $methods = isset($routeConfig['methods']) ? $routeConfig['methods'] : [Request::METHOD_GET];
+        $this->addRoute(new Route($path, $defaults, $requirements, [], '', [], $methods), $name);
     }
 
     /**
@@ -140,11 +154,14 @@ class Router
      * Add route.
      *
      * @param Route $route
+     * @param string|null $route
      */
-    public function addRoute(Route $route)
+    public function addRoute(Route $route, $name = null)
     {
-        // We use path as name (sees no use for names)
-        $this->routes->add($route->getPath(), $route);
+        if (null === $name) {
+            $name = $route->getPath();
+        }
+        $this->routes->add($name, $route);
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -39,7 +39,10 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             'defaultModule' => 'modDef',
             'defaultController' => 'conDef',
             'defaultAction' => 'actDef',
-            'routes' => ['/index/index' => ['defaults' => ['controller' => 'index', 'action' => 'index']]],
+            'routes' => [
+                '/index/index' => ['defaults' => ['controller' => 'index', 'action' => 'index']],
+                'foo-bar' => ['path' => '/foo/bar', 'defaults' => ['controller' => 'foo', 'action' => 'bar']],
+            ],
         ];
 
         $tmpObject = new Router($this->mockApp, $fakeOptions);
@@ -58,6 +61,38 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(4, $this->router->getRoutes());
         $this->router->clearRoutes();
         $this->assertCount(0, $this->router->getRoutes());
+    }
+
+    public function testAddRouteWithName()
+    {
+        $route = new Route('/foo/bar', [], ['controller' => '[a-z-]+', 'action' => '[a-z-]+']);
+
+        $this->assertCount(3, $this->router->getRoutes());
+        $this->router->addRoute($route, 'foo-bar');
+        $this->assertCount(4, ($routes = $this->router->getRoutes()));
+
+        $fetchedRoute = $routes->get('foo-bar');
+        $this->assertEquals('/foo/bar', $fetchedRoute->getPath());
+    }
+
+    public function testAddRouteWithHttpMethods()
+    {
+        $route = new Route(
+            '/foo/bar',
+            [],
+            ['controller' => '[a-z-]+', 'action' => '[a-z-]+'],
+            [],
+            '',
+            [],
+            ['POST', 'PUT', 'PATCH']
+        );
+
+        $this->assertCount(3, $this->router->getRoutes());
+        $this->router->addRoute($route);
+        $this->assertCount(4, ($routes = $this->router->getRoutes()));
+
+        $fetchedRoute = $routes->get('/foo/bar');
+        $this->assertCount(3, $fetchedRoute->getMethods());
     }
 
     public function testRoute()

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -55,10 +55,10 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     public function testAddClearRoute()
     {
         $mockRoute = $this->createMock('\Symfony\Component\Routing\Route');
-
-        $this->assertCount(3, $this->router->getRoutes());
+        $numberOfRoutes = $this->router->getRoutes()->count();
         $this->router->addRoute($mockRoute);
-        $this->assertCount(4, $this->router->getRoutes());
+
+        $this->assertCount($numberOfRoutes + 1, $this->router->getRoutes());
         $this->router->clearRoutes();
         $this->assertCount(0, $this->router->getRoutes());
     }
@@ -66,10 +66,11 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     public function testAddRouteWithName()
     {
         $route = new Route('/foo/bar', [], ['controller' => '[a-z-]+', 'action' => '[a-z-]+']);
-
-        $this->assertCount(3, $this->router->getRoutes());
+        $numberOfRoutes = $this->router->getRoutes()->count();
         $this->router->addRoute($route, 'foo-bar');
-        $this->assertCount(4, ($routes = $this->router->getRoutes()));
+        $routes = $this->router->getRoutes();
+
+        $this->assertCount($numberOfRoutes + 1, $routes);
 
         $fetchedRoute = $routes->get('foo-bar');
         $this->assertEquals('/foo/bar', $fetchedRoute->getPath());
@@ -86,13 +87,13 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             [],
             ['POST', 'PUT', 'PATCH']
         );
-
-        $this->assertCount(3, $this->router->getRoutes());
+        $numberOfRoutes = $this->router->getRoutes()->count();
         $this->router->addRoute($route);
-        $this->assertCount(4, ($routes = $this->router->getRoutes()));
+        $routes = $this->router->getRoutes();
+        $methods = $routes->get('/foo/bar')->getMethods();
 
-        $fetchedRoute = $routes->get('/foo/bar');
-        $this->assertCount(3, $fetchedRoute->getMethods());
+        $this->assertCount($numberOfRoutes + 1, $routes);
+        $this->assertCount(3, $methods);
     }
 
     public function testRoute()


### PR DESCRIPTION
This PR extends the routing by adding support for:

* route names
* HTTP methods 


Background
---
The Startlit routing implementation based on the `symfony/routing` component is quite limited and supports only a subset of the features provided by the component:

* routing names are not supported
* can not configure multiple routes for the same `path`
* can not configure HTTP methods for routes

A new `Route` just gets added like this:

```
$this->addRoute(new Route($path, $defaults, $requirements);
```
supporting only `path`, `defaults` and `requirements`, but the `Route` constructor supports a lot more optional attributes which should be (fully?) supported:

```
/**
 * Constructor.
 *
 * Available options:
 *
 *  * compiler_class: A class name able to compile this route instance (RouteCompiler by default)
 *  * utf8:           Whether UTF-8 matching is enforced ot not
 *
 * @param string          $path         The path pattern to match
 * @param array           $defaults     An array of default parameter values
 * @param array           $requirements An array of requirements for parameters (regexes)
 * @param array           $options      An array of options
 * @param string          $host         The host pattern to match
 * @param string|string[] $schemes      A required URI scheme or an array of restricted schemes
 * @param string|string[] $methods      A required HTTP method or an array of restricted methods
 * @param string          $condition    A condition that should evaluate to true for the route to match
 */
public function __construct($path, array $defaults = array(), array $requirements = array(), array $options = array(), $host = '', $schemes = array(), $methods = array(), $condition = '')
```
On top of that Starlit does not allow route names, thus does not allow support for multiple routes using the same path (e.g. with different HTTP methods):

```
/**
  * Add route.
  *
  * @param Route $route
  */
 public function addRoute(Route $route)
 {
     // We use path as name (sees no use for names)
     $this->routes->add($route->getPath(), $route);
 }
```
