### PR TITLE
Resolve controller actions via container

### DIFF
--- a/src/AbstractController.php
+++ b/src/AbstractController.php
@@ -165,6 +165,8 @@ abstract class AbstractController
                 $collectedArgs[] = $this->request->attributes->get($param->name);
             } elseif ($param->isDefaultValueAvailable()) {
                 $collectedArgs[] = $param->getDefaultValue();
+            } elseif ($param->getClass()) {
+                $collectedArgs[] = $this->app->resolveInstance($param->getClass()->getName());
             } else {
                 throw new \LogicException(
                     "Action method \"{$actionMethod}\" requires that you provide a value for the \"\${$param->name}\""

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -237,7 +237,7 @@ class Container implements ContainerInterface
      * @return mixed
      * @throws \ReflectionException
      */
-    private function resolveInstance(string $className)
+    public function resolveInstance(string $className)
     {
         $class = new \ReflectionClass($className);
 


### PR DESCRIPTION
This PR adds support to inject dependencies into controller actions. 

With this change it is possible to do the following:

**route configuration**
```php
'/foo/bar/{id}' => ['defaults' => ['controller' => 'foo', 'action' => 'bar', 'requirements' => ['id' => '\d+']]],
```

**controller action**
```php
class FooController extends AbstractController
{
    public function barAction(int $id, BarService $barService): Response
    {
        return new JsonResponse([
            'id' => $id,
            'bar' => $barService->bar(),
        ]);
    }
}
```