### PR TITLE
Resolve controller via container

### DIFF
--- a/src/AbstractController.php
+++ b/src/AbstractController.php
@@ -243,7 +243,16 @@ abstract class AbstractController implements ViewAwareControllerInterface
             $module = $module ?: $router->getRequestModule($this->request);
 
             $controllerClass = $router->getControllerClass($controller, $module);
-            $actualController = new $controllerClass($this->app, $this->request);
+            $actualController = $this->app->resolveInstance($controllerClass);
+            if (!$actualController instanceof ControllerInterface) {
+                throw new \LogicException('controller needs to implement ControllerInterface');
+            }
+            $actualController->setApp($this->app);
+            $actualController->setRequest($this->app->get(Request::class));
+            if ($actualController instanceof ViewAwareControllerInterface) {
+                $actualController->setView($this->app->getNew(ViewInterface::class));
+            }
+            $actualController->init();
 
             // Set new request properties
             $this->request->attributes->add(compact('module', 'controller', 'action'));

--- a/src/AbstractController.php
+++ b/src/AbstractController.php
@@ -51,8 +51,9 @@ abstract class AbstractController
      *
      * @param BaseApp $app
      * @param Request $request
+     * @param mixed $dependencies additional dependencies to be resolved by the container
      */
-    final public function __construct(BaseApp $app, Request $request)
+    public function __construct(BaseApp $app, Request $request, ...$toBeResolved)
     {
         $this->app = $app;
         $this->request = $request;

--- a/src/AbstractController.php
+++ b/src/AbstractController.php
@@ -19,7 +19,7 @@ use Starlit\Utils\Url;
  *
  * @author Andreas Nilsson <http://github.com/jandreasn>
  */
-abstract class AbstractController
+abstract class AbstractController implements ViewAwareControllerInterface
 {
     /**
      * @var BaseApp
@@ -46,28 +46,25 @@ abstract class AbstractController
      */
     protected $autoRenderViewScript;
 
-    /**
-     * Constructor.
-     *
-     * @param BaseApp $app
-     * @param Request $request
-     * @param mixed $dependencies additional dependencies to be resolved by the container
-     */
-    public function __construct(BaseApp $app, Request $request, ...$toBeResolved)
+    public function setApp(BaseApp $app)
     {
         $this->app = $app;
+    }
+
+    public function setRequest(Request $request)
+    {
         $this->request = $request;
+    }
 
-        $this->view = $this->app->getNew(ViewInterface::class);
-        $this->view->setRequest($this->request);
-
-        $this->init();
+    public function setView(ViewInterface $view)
+    {
+        $this->view = $view;
     }
 
     /**
      * Initialization method meant to be overridden in descendant classes (optional).
      */
-    protected function init()
+    public function init()
     {
     }
 

--- a/src/BaseApp.php
+++ b/src/BaseApp.php
@@ -178,7 +178,7 @@ class BaseApp extends Container
     }
 
     /**
-     * Handles an http request and returns a response.
+     * Handles a http request and returns a response.
      *
      * @param Request $request
      * @return Response

--- a/src/BaseApp.php
+++ b/src/BaseApp.php
@@ -195,8 +195,7 @@ class BaseApp extends Container
         }
 
         try {
-            $controller = $this->get(RouterInterface::class)->route($request);
-
+            $controller = $this->resolveController($request);
             if (($postRouteResponse = $this->postRoute($request))) {
                 return $postRouteResponse;
             }
@@ -263,5 +262,21 @@ class BaseApp extends Container
     public function getEnvironment()
     {
         return $this->environment;
+    }
+
+    private function resolveController(Request $request): ControllerInterface
+    {
+        $controller = $this->get(RouterInterface::class)->route($request);
+        if (!$controller instanceof ControllerInterface) {
+            throw new \LogicException('controller needs to implement ControllerInterface');
+        }
+        $controller->setApp($this);
+        $controller->setRequest($request);
+        if ($controller instanceof ViewAwareControllerInterface) {
+            $controller->setView($this->getNew(ViewInterface::class));
+        }
+        $controller->init();
+
+        return $controller;
     }
 }

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -237,7 +237,7 @@ class Container implements ContainerInterface
      * @return mixed
      * @throws \ReflectionException
      */
-    private function resolveInstance(string $className)
+    public function resolveInstance(string $className)
     {
         $class = new \ReflectionClass($className);
 
@@ -261,7 +261,7 @@ class Container implements ContainerInterface
      * @param \ReflectionParameter[]
      * @return mixed
      */
-    private function resolveParameters(array $parameters): array
+    public function resolveParameters(array $parameters): array
     {
         $values = [];
 

--- a/src/ControllerInterface.php
+++ b/src/ControllerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Starlit\App;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface ControllerInterface
+{
+    public function init();
+
+    public function setApp(BaseApp $app);
+
+    public function setRequest(Request $request);
+}

--- a/src/ControllerInterface.php
+++ b/src/ControllerInterface.php
@@ -6,9 +6,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 interface ControllerInterface
 {
-    public function init();
-
     public function setApp(BaseApp $app);
 
     public function setRequest(Request $request);
+
+    public function init();
+
+    public function dispatch();
 }

--- a/src/Provider/StandardServiceProvider.php
+++ b/src/Provider/StandardServiceProvider.php
@@ -13,6 +13,7 @@ use Starlit\App\Router;
 use Starlit\App\RouterInterface;
 use Starlit\App\View;
 use Starlit\App\ViewInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -28,6 +29,14 @@ class StandardServiceProvider implements ServiceProviderInterface
      */
     public function register(BaseApp $app)
     {
+        $app->set(BaseApp::class, function (BaseApp $app) {
+            return $app;
+        });
+
+        $app->set(Request::class, function (BaseApp $app) {
+            return Request::createFromGlobals();
+        });
+
         $app->alias('sessionStorage', SessionStorageInterface::class);
         $app->set(SessionStorageInterface::class, function (BaseApp $app) {
             if ($app->isCli()) {

--- a/src/Provider/StandardServiceProvider.php
+++ b/src/Provider/StandardServiceProvider.php
@@ -33,7 +33,7 @@ class StandardServiceProvider implements ServiceProviderInterface
             return $app;
         });
 
-        $app->set(Request::class, function (BaseApp $app) {
+        $app->set(Request::class, function () {
             return Request::createFromGlobals();
         });
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -216,7 +216,15 @@ class Router implements RouterInterface
             throw new ResourceNotFoundException("Action method \"{$controllerClass}::{$actionMethod}\" does not exist");
         }
 
-        $actualController = new $controllerClass($this->app, $request);
+        try {
+            $actualController = $this->app->resolveInstance($controllerClass);
+        } catch (\ReflectionException $exception) {
+            throw new \RuntimeException(
+                "controller [$controllerClass] could not be resolved by the container",
+                0,
+                $exception
+            );
+        }
 
         return $actualController;
     }

--- a/src/ViewAwareControllerInterface.php
+++ b/src/ViewAwareControllerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Starlit\App;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface ViewAwareControllerInterface extends ControllerInterface
+{
+    public function setView(ViewInterface $view);
+}

--- a/tests/AbstractControllerTest.php
+++ b/tests/AbstractControllerTest.php
@@ -59,16 +59,22 @@ class AbstractControllerTest extends \PHPUnit_Framework_TestCase
                     switch ($className) {
                         case Response::class:
                             return $this->mockResponse;
+                        case Request::class:
+                            return $this->mockRequest;
                         case RouterInterface::class:
                             return $this->mockRouter;
                     }
                 }
             ));
 
-        $this->testController = new TestController($this->mockApp, $this->mockRequest);
+        $testController = new TestController();
+        $testController->setApp($this->mockApp);
+        $testController->setRequest($this->mockRequest);
+        $testController->setView($this->mockView);
+        $this->testController = $testController;
     }
 
-    public function testConstruct()
+    public function testViewProperty()
     {
         // check view
         $rObject = new \ReflectionObject($this->testController);
@@ -250,6 +256,9 @@ class AbstractControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testForward()
     {
+        $this->mockApp->expects($this->once())
+            ->method('resolveInstance')
+            ->willReturn($this->testController);
         $this->mockRouter = $this->createMock(Router::class);
         $this->mockRouter->expects($this->once())
             ->method('getRequestModule')
@@ -274,6 +283,9 @@ class AbstractControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testForwardWithModule()
     {
+        $this->mockApp->expects($this->once())
+                      ->method('resolveInstance')
+                      ->willReturn($this->testController);
         $this->mockRouter = $this->createMock(Router::class);
         $this->mockRouter->expects($this->once())
             ->method('getControllerClass')

--- a/tests/BaseAppTest.php
+++ b/tests/BaseAppTest.php
@@ -244,7 +244,7 @@ class BaseAppTest extends \PHPUnit_Framework_TestCase
 
     public function testHasNoRequest()
     {
-        $this->assertFalse($this->app->has(Request::class));
+        $this->assertTrue($this->app->has(Request::class));
     }
 }
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -98,6 +98,10 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
     public function testRoute()
     {
+        $this->mockApp->expects($this->once())
+                      ->method('resolveInstance')
+                      ->willReturn(new RouterTestController());
+
         // Mock controller get
         $partiallyMockedRouter = $this->getMockBuilder(\Starlit\App\Router::class)
             ->setMethods(['getControllerClass'])


### PR DESCRIPTION
This PR extends the DIC feature with support to resolve the controller instances from the container:

```php
class FooController extends AbstractController
{
    /**
     * @var BarService
     */
    private $barService;

    /**
     * FooController constructor.
     *
     * @param BarService $barService
     */
    public function __construct(BarService $barService)
    {
        $this->barService = $barService;
    }

    public function barAction(int $id): Response
    {
        $bar = $this->barService->bar();

        return Response::create("Hello $bar (id: $id)");
    }
}
```

To be able to support constructor based DI and to avoid that a missing `parent::__construct` call would break the supported flow of the `AbstractController` I have decided to remove the final constructor from `AbstractController`and to implement the `BaseApp` against a new `ControllerInterface` :

```php
interface ControllerInterface
{
    public function setApp(BaseApp $app);

    public function setRequest(Request $request);

    public function init();

    public function dispatch();
}
```

A new `ViewAwareControllerInterface` adds support for the View if needed and is implemented by the `AbstractController`.

There is some code duplication in the `AbstractController::foward` method setting the required dependencies via setter injection, so maybe a dedicated `ControllerResolver` or similar would be better. 

One breaking change has been introduced which can be fixed quite simple when upgrading: the visibility of the `AbstractController::init` method needed to be change to `public`. 

I am open to suggestions if there is a better way to provide this feature and of course to feedback regarding this approach ;-)
