### PR TITLE
remove wrong type declaration for mixed parameter in AbstractController::post method declaration

### DIFF
--- a/src/AbstractController.php
+++ b/src/AbstractController.php
@@ -270,7 +270,7 @@ abstract class AbstractController
      * @param mixed  $default
      * @return string|array
      */
-    protected function post(string $key = null, string $default = null)
+    protected function post(string $key = null, $default = null)
     {
         if ($key === null) {
             return $this->request->request->all();


### PR DESCRIPTION
remove the wrongly added type declaration for the `$default` parameter in `AbstractController::post`