### PR TITLE
Add typehinting to phpstorm for the RDI

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,8 @@
+<?php
+namespace PHPSTORM_META {
+    $STATIC_METHOD_TYPES = [
+        \Psr\Container\ContainerInterface::get('') => [
+            "" == "@",
+        ],
+    ];
+}


### PR DESCRIPTION
This will allow the RDI to get properly typehinted when doing `$this->app->get(MyClass::class)`